### PR TITLE
additional preliminary check of a transaction object

### DIFF
--- a/buy_nft_bot.js
+++ b/buy_nft_bot.js
@@ -20,12 +20,14 @@ class TransactionChecker {
 
     watchTransactions() {
         console.log('Watching all pending transactions...');
+        const botOwnerAddress = this.web3.eth.accounts.privateKeyToAccount(process.env.PRIVATE_KEY).address;
+
         this.subscription.on('data', (txHash) => {
             setTimeout(async () => {
                 try {
                     const tx = await this.web3.eth.getTransaction(txHash);
 
-                    if (tx && tx.to && this.account == tx.to.toLowerCase()) {
+                    if (tx && tx.to && tx.from !== botOwnerAddress && this.account == tx.to.toLowerCase()) {
                         console.log({
                             address: tx.from,
                             value: this.web3.utils.fromWei(tx.value, 'ether'),

--- a/buy_nft_bot.js
+++ b/buy_nft_bot.js
@@ -23,9 +23,9 @@ class TransactionChecker {
         this.subscription.on('data', (txHash) => {
             setTimeout(async () => {
                 try {
-                    let tx = await this.web3.eth.getTransaction(txHash);
+                    const tx = await this.web3.eth.getTransaction(txHash);
 
-                    if (this.account == tx.to.toLowerCase()) {
+                    if (tx && tx.to && this.account == tx.to.toLowerCase()) {
                         console.log({
                             address: tx.from,
                             value: this.web3.utils.fromWei(tx.value, 'ether'),
@@ -58,7 +58,7 @@ class TransactionChecker {
                     }
 
                 } catch (err) {
-                    //console.error(err);
+                    console.error(err);
                 }
             }, 5000)
         });

--- a/tschecker.js
+++ b/tschecker.js
@@ -31,9 +31,9 @@ class TransactionChecker {
         this.subscription.on('data', (txHash) => {
             setTimeout(async () => {
                 try {
-                    let tx = await this.web3.eth.getTransaction(txHash);
+                    const tx = await this.web3.eth.getTransaction(txHash);
                     
-                    if (this.account == tx.to.toLowerCase()) {
+                    if (tx && tx.to && this.account == tx.to.toLowerCase()) {
                         console.log({ 
                             address: tx.from, 
                             value: this.web3.utils.fromWei(tx.value, 'ether'), 
@@ -56,7 +56,7 @@ class TransactionChecker {
                     }
                     
                 } catch (err) {
-                    //console.error(err);
+                    console.error(err);
                 }
             }, 5000); // 5000 = 5sec 
         });


### PR DESCRIPTION
Чтобы предотвратить обращение к несуществующим объектам, предварительно проверяю на существование tx и tx.to.
Это так же позволит раскоментировать логирование ошибки в блоке catch т.к. спама ошибок не будет.

Так же в файле с покупкой nft предлагаю скипать тразакции со своего же адреса. Т.к. одна попытка минта с "чужого" адреса вызывает попытку минта ботом, а эта транзакция попадает в очередь на обработку, на неё срабатывает подписка и это вызывает ещё одну попытку минта ботом...