### PR TITLE
setTimeout removed

### DIFF
--- a/buy_nft_bot.js
+++ b/buy_nft_bot.js
@@ -20,8 +20,7 @@ class TransactionChecker {
 
     watchTransactions() {
         console.log('Watching all pending transactions...');
-        this.subscription.on('data', (txHash) => {
-            setTimeout(async () => {
+        this.subscription.on('data', async (txHash) => {
                 try {
                     let tx = await this.web3.eth.getTransaction(txHash);
 
@@ -60,7 +59,6 @@ class TransactionChecker {
                 } catch (err) {
                     //console.error(err);
                 }
-            }, 5000)
         });
     }
 }

--- a/tschecker.js
+++ b/tschecker.js
@@ -28,8 +28,7 @@ class TransactionChecker {
 
     watchTransactions() {
         console.log('Watching all pending transactions...');
-        this.subscription.on('data', (txHash) => {
-            setTimeout(async () => {
+        this.subscription.on('data', async (txHash) => {
                 try {
                     let tx = await this.web3.eth.getTransaction(txHash);
                     
@@ -58,7 +57,6 @@ class TransactionChecker {
                 } catch (err) {
                     //console.error(err);
                 }
-            }, 5000); // 5000 = 5sec 
         });
     }
 }


### PR DESCRIPTION
Не совсем понял назначения setTimeout. Возможно он имел какое-то назначение в скрипте, взятом за основу (я не смотрел).
Евенты с ожидающей обработки транзакцией поступают к нам не раз в 5 секунд, а с частотой с которой ws api инфуры присылает уведомления.
Но вот обработку этой транзакции мы начинаем через 5 секунд после получения. Что выглядит немного странно, если учесть что мы хотим заминтить nft вперёд кого-то.

Предлагаю удалить setTimeout и начать обработку транзакции сразу после получения информации о ней.